### PR TITLE
feat: add regression fit functions (Spearman, RMSE, MI)

### DIFF
--- a/src/param.rs
+++ b/src/param.rs
@@ -27,6 +27,12 @@ pub enum FitFunction {
     ppv,
     /// Geometric Mean of sensitivity and specificity
     g_mean,
+    /// Spearman rank correlation (regression mode)
+    spearman,
+    /// Root Mean Squared Error (regression mode, negated so higher = better)
+    rmse,
+    /// Mutual Information (regression/classification)
+    mutual_information,
 }
 
 /// Confidence interval methods for Family of Best Models (FBM) selection.

--- a/src/population.rs
+++ b/src/population.rs
@@ -368,13 +368,18 @@ impl Population {
             if let Some(ref mut threshold_ci) = i.cls.threshold_ci {
                 i.fit = i.fit - (param.general.threshold_ci_penalty * threshold_ci.rejection_rate);
             };
-            // Bias penalty
-            if param.general.bias_penalty != 0.0 {
+            // Bias penalty (classification only — not applicable for regression)
+            if param.general.bias_penalty != 0.0
+                && !matches!(
+                    param.general.fit,
+                    FitFunction::spearman | FitFunction::rmse | FitFunction::mutual_information
+                )
+            {
                 if i.cls.sensitivity < 0.5 {
-                    i.fit = i.fit - (1.0 - i.cls.sensitivity) * param.general.bias_penalty
+                    i.fit -= (1.0 - i.cls.sensitivity) * param.general.bias_penalty
                 };
                 if i.cls.specificity < 0.5 {
-                    i.fit = i.fit - (1.0 - i.cls.specificity) * param.general.bias_penalty
+                    i.fit -= (1.0 - i.cls.specificity) * param.general.bias_penalty
                 };
             };
             // User penalties
@@ -474,6 +479,9 @@ impl Population {
                 let penalties = match param.general.fit {
                     FitFunction::sensitivity => Some([param.general.fr_penalty, 1.0]),
                     FitFunction::specificity => Some([1.0, param.general.fr_penalty]),
+                    FitFunction::spearman | FitFunction::rmse | FitFunction::mutual_information => {
+                        None
+                    }
                     _ => None,
                 };
                 match param.general.fit {
@@ -533,6 +541,18 @@ impl Population {
                             }
                         }
                         i.fit = i.cls.auc;
+                    }
+                    FitFunction::spearman => {
+                        let y_f64: Vec<f64> = data.y.iter().map(|&v| v as f64).collect();
+                        i.fit = crate::utils::spearman_correlation(&scores, &y_f64);
+                    }
+                    FitFunction::rmse => {
+                        let y_f64: Vec<f64> = data.y.iter().map(|&v| v as f64).collect();
+                        i.fit = crate::utils::neg_rmse(&scores, &y_f64);
+                    }
+                    FitFunction::mutual_information => {
+                        let y_f64: Vec<f64> = data.y.iter().map(|&v| v as f64).collect();
+                        i.fit = crate::utils::mutual_information(&scores, &y_f64);
                     }
                     _ => {
                         if let Some(ref mut threshold_ci) = i.cls.threshold_ci {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -703,6 +703,8 @@ pub fn compute_roc_and_metrics_from_value(
         FitFunction::npv => npv(0, 0),
         FitFunction::ppv => ppv(tp_init, fp_init),
         FitFunction::g_mean => g_mean(sens_init, spec_init),
+        // Regression metrics — threshold optimization not applicable
+        FitFunction::spearman | FitFunction::rmse | FitFunction::mutual_information => 0.0,
     };
 
     if obj_init > best_objective {
@@ -759,6 +761,7 @@ pub fn compute_roc_and_metrics_from_value(
             FitFunction::npv => npv(tn, fn_count),
             FitFunction::ppv => ppv(tp, fp),
             FitFunction::g_mean => g_mean(sensitivity, specificity),
+            FitFunction::spearman | FitFunction::rmse | FitFunction::mutual_information => 0.0,
         };
 
         if objective > best_objective {
@@ -885,6 +888,155 @@ fn apply_threshold_balance(sensitivity: f64, specificity: f64, penalties: Option
 /// assert!((mean - 3.0).abs() < 1e-6);
 /// assert!((std - 1.4142135).abs() < 1e-6);
 /// ```
+/// Compute Spearman rank correlation coefficient between two vectors.
+///
+/// Returns a value in [-1, 1]. +1 = perfect positive rank correlation,
+/// -1 = perfect negative, 0 = no correlation.
+///
+/// Handles ties using average ranks.
+pub fn spearman_correlation(x: &[f64], y: &[f64]) -> f64 {
+    assert_eq!(x.len(), y.len(), "Spearman: vectors must have equal length");
+    let n = x.len();
+    if n < 2 {
+        return 0.0;
+    }
+
+    // Compute ranks with tie-handling (average rank method)
+    fn rank(v: &[f64]) -> Vec<f64> {
+        let n = v.len();
+        let mut indexed: Vec<(usize, f64)> = v.iter().cloned().enumerate().collect();
+        indexed.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal));
+
+        let mut ranks = vec![0.0; n];
+        let mut i = 0;
+        while i < n {
+            let mut j = i;
+            // Find tied group
+            while j < n - 1 && (indexed[j + 1].1 - indexed[j].1).abs() < 1e-12 {
+                j += 1;
+            }
+            // Average rank for tied group
+            let avg_rank = (i + j) as f64 / 2.0 + 1.0;
+            for k in i..=j {
+                ranks[indexed[k].0] = avg_rank;
+            }
+            i = j + 1;
+        }
+        ranks
+    }
+
+    let rx = rank(x);
+    let ry = rank(y);
+
+    // Pearson correlation on ranks
+    let n_f = n as f64;
+    let mean_rx: f64 = rx.iter().sum::<f64>() / n_f;
+    let mean_ry: f64 = ry.iter().sum::<f64>() / n_f;
+
+    let mut cov = 0.0;
+    let mut var_x = 0.0;
+    let mut var_y = 0.0;
+
+    for i in 0..n {
+        let dx = rx[i] - mean_rx;
+        let dy = ry[i] - mean_ry;
+        cov += dx * dy;
+        var_x += dx * dx;
+        var_y += dy * dy;
+    }
+
+    if var_x == 0.0 || var_y == 0.0 {
+        return 0.0;
+    }
+
+    cov / (var_x.sqrt() * var_y.sqrt())
+}
+
+/// Compute negative Root Mean Squared Error between predictions and targets.
+///
+/// Returns -RMSE so that higher = better (consistent with other fit functions).
+pub fn neg_rmse(predictions: &[f64], targets: &[f64]) -> f64 {
+    assert_eq!(
+        predictions.len(),
+        targets.len(),
+        "RMSE: vectors must have equal length"
+    );
+    let n = predictions.len();
+    if n == 0 {
+        return 0.0;
+    }
+    let mse: f64 = predictions
+        .iter()
+        .zip(targets.iter())
+        .map(|(p, t)| (p - t).powi(2))
+        .sum::<f64>()
+        / n as f64;
+    -mse.sqrt()
+}
+
+/// Compute mutual information between two continuous vectors using histogram binning.
+///
+/// Uses 10 bins for each variable. Returns MI in nats (natural log).
+pub fn mutual_information(x: &[f64], y: &[f64]) -> f64 {
+    assert_eq!(
+        x.len(),
+        y.len(),
+        "Mutual information: vectors must have equal length"
+    );
+    let n = x.len();
+    if n < 2 {
+        return 0.0;
+    }
+
+    let n_bins = 10usize;
+
+    // Bin boundaries
+    fn bin_values(v: &[f64], n_bins: usize) -> Vec<usize> {
+        let min = v.iter().cloned().fold(f64::INFINITY, f64::min);
+        let max = v.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
+        let range = max - min;
+        if range == 0.0 {
+            return vec![0; v.len()];
+        }
+        v.iter()
+            .map(|&val| {
+                let bin = ((val - min) / range * (n_bins as f64 - 1e-10)) as usize;
+                bin.min(n_bins - 1)
+            })
+            .collect()
+    }
+
+    let bx = bin_values(x, n_bins);
+    let by = bin_values(y, n_bins);
+
+    // Joint and marginal counts
+    let mut joint = vec![vec![0usize; n_bins]; n_bins];
+    let mut mx = vec![0usize; n_bins];
+    let mut my = vec![0usize; n_bins];
+
+    for i in 0..n {
+        joint[bx[i]][by[i]] += 1;
+        mx[bx[i]] += 1;
+        my[by[i]] += 1;
+    }
+
+    // MI = Σ p(x,y) * log(p(x,y) / (p(x) * p(y)))
+    let n_f = n as f64;
+    let mut mi = 0.0;
+    for i in 0..n_bins {
+        for j in 0..n_bins {
+            if joint[i][j] > 0 && mx[i] > 0 && my[j] > 0 {
+                let pxy = joint[i][j] as f64 / n_f;
+                let px = mx[i] as f64 / n_f;
+                let py = my[j] as f64 / n_f;
+                mi += pxy * (pxy / (px * py)).ln();
+            }
+        }
+    }
+    mi
+}
+
+/// Computes mean and standard deviation using Welford's algorithm.
 pub fn mean_and_std(values: &[f64]) -> (f64, f64) {
     let mut n = 0.0;
     let (mut mean, mut m2) = (0.0, 0.0); // Welford
@@ -6037,5 +6189,78 @@ mod tests {
             lo_w,
             lo_a
         );
+    }
+}
+
+#[cfg(test)]
+mod regression_tests {
+    use super::*;
+
+    #[test]
+    fn test_spearman_perfect_positive() {
+        let x = vec![1.0, 2.0, 3.0, 4.0, 5.0];
+        let y = vec![10.0, 20.0, 30.0, 40.0, 50.0];
+        let rho = spearman_correlation(&x, &y);
+        assert!((rho - 1.0).abs() < 1e-10, "Perfect positive: {}", rho);
+    }
+
+    #[test]
+    fn test_spearman_perfect_negative() {
+        let x = vec![1.0, 2.0, 3.0, 4.0, 5.0];
+        let y = vec![50.0, 40.0, 30.0, 20.0, 10.0];
+        let rho = spearman_correlation(&x, &y);
+        assert!((rho + 1.0).abs() < 1e-10, "Perfect negative: {}", rho);
+    }
+
+    #[test]
+    fn test_spearman_no_correlation() {
+        let x = vec![1.0, 2.0, 3.0, 4.0, 5.0];
+        let y = vec![3.0, 1.0, 5.0, 2.0, 4.0];
+        let rho = spearman_correlation(&x, &y);
+        assert!(rho.abs() < 0.5, "Low correlation: {}", rho);
+    }
+
+    #[test]
+    fn test_spearman_with_ties() {
+        let x = vec![1.0, 2.0, 2.0, 4.0, 5.0];
+        let y = vec![1.0, 3.0, 3.0, 4.0, 5.0];
+        let rho = spearman_correlation(&x, &y);
+        assert!(rho > 0.9, "High correlation with ties: {}", rho);
+    }
+
+    #[test]
+    fn test_neg_rmse_zero_error() {
+        let p = vec![1.0, 2.0, 3.0];
+        let t = vec![1.0, 2.0, 3.0];
+        let r = neg_rmse(&p, &t);
+        assert!((r - 0.0).abs() < 1e-10, "Zero error: {}", r);
+    }
+
+    #[test]
+    fn test_neg_rmse_nonzero() {
+        let p = vec![1.0, 2.0, 3.0];
+        let t = vec![1.1, 2.2, 2.8];
+        let r = neg_rmse(&p, &t);
+        assert!(r < 0.0, "Negative RMSE: {}", r);
+        assert!(r > -1.0, "Bounded: {}", r);
+    }
+
+    #[test]
+    fn test_mutual_information_identical() {
+        let x = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0];
+        let y = x.clone();
+        let mi = mutual_information(&x, &y);
+        assert!(
+            mi > 0.0,
+            "MI of identical vectors should be positive: {}",
+            mi
+        );
+    }
+    #[test]
+    fn test_mutual_information_nonnegative() {
+        let x: Vec<f64> = (0..50).map(|i| i as f64).collect();
+        let y: Vec<f64> = (0..50).map(|i| (i * 3 + 7) as f64).collect();
+        let mi = mutual_information(&x, &y);
+        assert!(mi >= 0.0, "MI should be non-negative: {}", mi);
     }
 }


### PR DESCRIPTION
## Summary
Add three regression fitness functions: Spearman rank correlation, RMSE, and Mutual Information.

This validates the ClassificationMetrics refactor (#45) — regression models use `fit` but leave `cls` fields at their defaults.

## New fit functions

| Function | Range | Higher = | Use case |
|----------|-------|----------|----------|
| `spearman` | [-1, 1] | Better correlation | Rank-based regression |
| `rmse` | (-∞, 0] | Less error | Continuous prediction |
| `mutual_information` | [0, ∞) | More information | Non-linear relationships |

## Usage
```yaml
general:
  fit: spearman  # or rmse, mutual_information
```

## Test plan
- [x] 764 lib tests pass (8 new regression tests)
- [x] Spearman: perfect positive/negative, ties, no correlation
- [x] RMSE: zero error, nonzero
- [x] MI: identical vectors, non-negative

Closes #15