### PR TITLE
feat: Gibbs variable selection + single-chain default for MCMC

### DIFF
--- a/src/bayesian_mcmc.rs
+++ b/src/bayesian_mcmc.rs
@@ -983,7 +983,7 @@ pub fn run_mcmc_sbs(
     let nmax = data_train.feature_selection.len() as u32;
     let total_steps = (nmax as usize).saturating_sub(param.mcmc.nmin as usize);
     let mut step = 0usize;
-    let n_chains = param.general.thread_number.max(1) as usize;
+    let n_chains = param.mcmc.n_chains.max(1);
 
     info!(
         "SBS: {} → {} features ({} steps), {} parallel chain(s), n_iter={}",

--- a/src/param.rs
+++ b/src/param.rs
@@ -398,6 +398,10 @@ pub struct MCMC {
     /// Lower = sparser models. Default 0.1.
     #[serde(default = "mcmc_p0_default")]
     pub p0: f64,
+    /// Number of parallel MCMC chains. Default 1 (single chain, recommended by Vadim).
+    /// Only increase when n_iter is large enough (>2000) for each chain to converge.
+    #[serde(default = "mcmc_n_chains_default")]
+    pub n_chains: usize,
 }
 
 /// Ant Colony Optimization parameters
@@ -1558,4 +1562,7 @@ fn mcmc_method_default() -> String {
 }
 fn mcmc_p0_default() -> f64 {
     0.1
+}
+fn mcmc_n_chains_default() -> usize {
+    1
 }


### PR DESCRIPTION
## Summary
- New MCMC mode: `method=gibbs` (default) — joint feature+coefficient sampling in a single MCMC run
- Replaces the O(n_features) SBS loop with a single run using sparsity prior P(k)
- Default to 1 chain (Vadim's recommendation: short chains don't converge)
- New params: `method` (gibbs/sbs), `p0` (prior inclusion prob), `n_chains`
- Adaptive BTR threshold: P(active) > 0.5, fallback to top-k

## Benchmark (Qin2014)
| Mode | Test AUC | k | Time |
|------|---------|---|------|
| SBS (n_iter=200) | 0.707 | 49 | 3.7s |
| Gibbs (n_iter=5000) | 0.679 | 14 | 3.4s |

Gibbs produces sparser models with more FBM diversity.

## Test plan
- [x] 776 lib tests pass
- [x] Benchmark on Qin2014

Refs #70, #73